### PR TITLE
pathy 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36 or s390x]
+  skip: True  # [py<36 or s390x or win32]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pathy=pathy.cli:app

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pathy=pathy.cli:app

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pathy" %}
-{% set version = "0.6.0" %}
+{% set version = "0.6.1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: f83f1eddf77dd86e824143eef8d9adbe0785c3cdd5ec0ed6c0edea3227385048
+    sha256: 838624441f799a06b446a657e4ecc9ebc3fdd05234397e044a7c87e8f6e76b1c
 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,22 +13,22 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - pathy=pathy.cli:app
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - wheel
     - setuptools
   run:
-    - python >=3.6
+    - python
     - smart_open >=5.0.0,<6.0.0
     - typer >=0.3.0,<1.0.0
-    - dataclasses >=0.6,<1.0
+    - dataclasses >=0.6,<1.0  # [py<37]
 
 test:
   imports:
@@ -42,6 +42,7 @@ test:
 about:
   home: https://github.com/justindujardin/pathy
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: A Path interface for local and cloud bucket storage
   description: |
@@ -51,7 +52,7 @@ about:
     supporting local file-system backed buckets during development and testing.
     It makes converting bucket blobs into local files a snap with optional
     local file caching of blobs.
-  doc_url: https://github.com/justindujardin/pathy
+  doc_url: https://github.com/justindujardin/pathy/blob/master/README.md
   dev_url: https://github.com/justindujardin/pathy
 
 extra:


### PR DESCRIPTION
Update pathy to 0.6.1

Changelog: https://github.com/justindujardin/pathy/blob/v0.6.1/CHANGELOG.md
License: https://github.com/justindujardin/pathy/blob/v0.6.1/LICENSE
Requirements:
 - https://github.com/justindujardin/pathy/blob/v0.6.1/requirements.txt
 - https://github.com/justindujardin/pathy/blob/v0.6.1/setup.py

Actions:
1. Remove noarch: python
2. Skip py<36 and s390x, and win32
3. Fix python
4. Add pinning for dataclasses
5. Add license_family
6. Update doc_url