### PR TITLE
pathy 0.10.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  # Python 3.12 isn't compatible
+  # Python 3.12 isn't compatible, see https://github.com/justindujardin/pathy/issues/106
   skip: True  # [py<36 or py>312 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36 or s390x]
+  # Python 3.12 isn't compatible
+  skip: True  # [py<36 or py>312 s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - pathy=pathy.cli:app

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   # Python 3.12 isn't compatible
-  skip: True  # [py<36 or py>312 s390x]
+  skip: True  # [py<36 or py>312 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - pathy=pathy.cli:app

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pathy" %}
-{% set version = "0.10.1" %}
+{% set version = "0.10.3" %}
 
 
 package:
@@ -8,13 +8,13 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 4cd6e71b4cd5ff875cfbb949ad9fa5519d8d1dbe69d5fc1d1b23aa3cb049618b
+    sha256: b45185d06f9b18c6d3346d3aab881ab96874553f661ee88ccd2e60246e103c22
 
 
 build:
   number: 0
   skip: True  # [py<36 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - pathy=pathy.cli:app
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   # Python 3.12 isn't compatible, see https://github.com/justindujardin/pathy/issues/106
-  skip: True  # [py<36 or py>312 or s390x]
+  skip: True  # [py<36 or py>=312 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - pathy=pathy.cli:app


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3709](https://anaconda.atlassian.net/browse/PKG-3709) 
- [Upstream repository](https://github.com/justindujardin/pathy/tree/v0.10.3)
- Changelog: https://github.com/justindujardin/pathy/blob/v0.10.3/CHANGELOG.md
- License: https://github.com/justindujardin/pathy/blob/v0.10.3/LICENSE
- Requirements:
 - https://github.com/justindujardin/pathy/blob/v0.10.3/requirements.txt
 - https://github.com/justindujardin/pathy/blob/v0.10.3/setup.py
 
### Explanation of changes:

- Update `script`
- Skip `py>312`, see https://github.com/justindujardin/pathy/issues/106

### Notes:

- It's a test dependency for `thinc` https://github.com/AnacondaRecipes/thinc-feedstock/pull/15
-

[PKG-3709]: https://anaconda.atlassian.net/browse/PKG-3709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ